### PR TITLE
Adding Storage module documentation - API and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This documentation website is built using [Docusaurus 2](https://docusaurus.io/)
 - `docs/train` provides docs for FEDML®Train
 - `docs/deploy` provides docs for FEDML®Deploy
 - `docs/federate` provides docs for FEDML®Federate (reusing our existing contents from federated learning)
+- `docs/storage` provides docs for FEDML® Storage
 
 # How to edit and release?
 

--- a/docs/launch/on-prem/_category_.json
+++ b/docs/launch/on-prem/_category_.json
@@ -3,6 +3,6 @@
   "position": 3,
   "link": {
     "type": "generated-index",
-    "description": "5 minutes to learn the most important Docusaurus concepts."
+    "description": "5 minutes to learn the most important FEDML On-Premise Deployment concepts."
   }
 }

--- a/docs/open-source/api/api-global.md
+++ b/docs/open-source/api/api-global.md
@@ -16,3 +16,4 @@ sidebar_position: 1
 
 ### `fedml.model.`
 
+

--- a/docs/open-source/api/api-storage.md
+++ b/docs/open-source/api/api-storage.md
@@ -1,0 +1,315 @@
+---
+sidebar_position: 7
+---
+
+# FEDML Storage APIs
+
+## Storage APIs
+
+Storage APIs help in managing all the data needs that is typically associated with AI workloads.
+
+:::tip
+Before using some of the apis that require remote operation (e.g. `fedml.api.launch_job()`), please use one of the following methods to login 
+to FedML MLOps platform first:
+
+1. CLI: `fedml login $api_key`
+
+2. API: `fedml.api.fedml_login(api_key=$api_key)`
+:::
+
+### `fedml.api.upload()`
+
+Upload data on FEDML® Nexus AI Platform
+
+```py
+def upload(data_path, api_key=None, service="R2", name=None, description=None, metadata=None, show_progress=False,
+           out_progress_to_err=True, progress_desc=None)-> FedMLResponse
+```
+
+**Arguments**
+
+- `data_path (str)`: path to the data.
+- `api_key (str=None)`: Your API key from FedML AI Nexus platform (if not configured already).
+- `service (str)`: The backend cloud storage service for storing the data. Currently, only Cloudfare R2 service is available.
+- `name (str)`: The name of the data stored on the cloud. If not specified, it'll take the name of the data file or directory.
+- `description (str)`: A description in string for the data being stored. If not provided, the description will be empty.
+- `metadata (dict)`: Metadata for the data that can be specified by the user in the form of a dictionary. Both the key and values have to be strings.
+- `show_progress (bool)`: Boolean flag to show a progress bar when the upload happens.
+- `out_progress_to_err (bool)`: Boolean flag to output the tqdm progress to stderr instead of stdout.
+- `progress_desc(str)`: String message that is displayed next to the progress bar when the data is uploaded. If not specified, the text : "Uploading Package to Remote Storage" will be used.
+
+**Returns**
+
+`FedMLResponse` object with the following attributes:
+- `code (Enum Class)`: API result code. The FedML response codes can be seen at the end of this page.
+- `message (str)`: API status message.
+- `data(obj)`: If the upload is successful, the url of the uploaded file is sent via this attribute.
+
+
+**Example**
+
+```py
+import fedml
+API_KEY = "api_key"
+
+DATA_PATH = "path/to/data"
+DATA_NAME = "new_name_for_data_directory or file"
+STORAGE_SERVICE = "R2"
+DATA_DESCRIPTION = "description of data uploaded"
+metadata = {'key': 'value'}
+
+response = fedml.api.upload(
+    data_path=DATA_PATH,
+    api_key=API_KEY,
+    service=STORAGE_SERVICE,
+    name=DATA_NAME,
+    description=DATA_DESCRIPTION,
+    metadata=metadata,
+    show_progress=True
+)
+```
+---
+### `fedml.api.download()`
+
+Download data stored on FEDML® Nexus AI Platform
+
+```py
+def download(data_name, api_key=None, service="R2", dest_path=None, show_progress=True) -> FedMLResponse
+```
+
+**Arguments**
+
+- `data_name (str)`: The name of the data that was uploaded to FedML cloud storage.
+- `api_key (str=None)`: Your API key from FedML AI Nexus platform (if not configured already).
+- `service (str)`: The backend cloud storage service for storing the data. Currently, only Cloudfare R2 service is available.
+- `dest_path (str)`: The name of the directory where the downloaded data needs to be stored.
+- `show_progress (bool)`: Boolean flag to show a progress bar when the upload happens.
+
+
+**Returns**
+
+`FedMLResponse` object with the following attributes:
+- `code (Enum Class)`: API result code. The FedML response codes can be seen at the end of this page.
+- `message (str)`: API status message.
+- `data(obj)`: If the download is successful, the filepath to where it is downloaded is returned.
+
+
+**Example**
+
+```py
+import fedml
+API_KEY = "api_key"
+
+DESTINATION_DIRECTORY = "dataset"
+DATA_NAME = "name_of_data_directory" #The name that was provided to platform during upload.
+STORAGE_SERVICE = "R2"
+
+
+response = fedml.api.download(
+    data_name=DATA_NAME,
+    api_key=API_KEY,
+    service=STORAGE_SERVICE,
+    dest_path=DESTINATION_DIRECTORY,
+    show_progress=True
+)
+```
+---
+### `fedml.api.delete()`
+
+Delete data stored on FEDML® Nexus AI Platform
+
+```py
+def delete(data_name, service, api_key=None)-> FedMLResponse
+```
+
+**Arguments**
+
+- `data_name (str)`: The name of the data that was uploaded to FedML cloud storage.
+- `api_key (str=None)`: Your API key from FedML AI Nexus platform (if not configured already).
+- `service (str)`: The backend cloud storage service for storing the data. Currently, only Cloudfare R2 service is available.
+
+
+**Returns**
+
+`FedMLResponse` object with the following attributes:
+- `code (Enum Class)`: API result code. The FedML response codes can be seen at the end of this page.
+- `message (str)`: API status message.
+- `data(obj)`: A `boolean` flag to show if the delete was successful.
+
+
+**Example**
+
+```py
+import fedml
+API_KEY = "api_key"
+DATA_NAME = "name_of_data_directory"
+STORAGE_SERVICE = "R2" 
+
+response = fedml.api.delete(
+    data_name=DATA_NAME,
+    api_key=API_KEY,
+    service=STORAGE_SERVICE
+)
+if response.code == ResponseCode.SUCCESS:
+    print(f"Data '{DATA_NAME}' deleted successfully.")
+else:
+    print(f"Failed to delete data {DATA_NAME}. Error message: {response.message}")
+```
+---
+### `fedml.api.get_storage_metadata()`
+
+Get metadata of a data object stored on FEDML® Nexus AI Platform
+
+```py
+def get_storage_metadata(data_name, api_key=None) -> FedMLResponse
+```
+
+**Arguments**
+
+- `data_name (str)`: The name of the data that was uploaded to FedML cloud storage.
+- `api_key (str=None)`: Your API key from FedML AI Nexus platform (if not configured already).
+
+**Returns**
+
+`FedMLResponse` object with the following attributes:
+- `code (Enum Class)`: API result code. The FedML response codes can be seen at the end of this page.
+- `message (str)`: API status message.
+- `data(obj)`: If the get_storage_metadata call is successful, then this object contains the `meta data information`.
+
+
+**Example**
+
+```py
+import fedml
+API_KEY = "api_key"
+DATA_NAME = "name_of_data_directory" #The name that was provided to platform during upload.
+
+response = fedml.api.get_storage_metadata(
+    data_name=DATA_NAME,
+    api_key=API_KEY
+)
+```
+
+**Parsing the output**
+
+The following code shows how the response.data can be parsed to a pretty table.
+
+```py
+from prettytable import PrettyTable
+from fedml.api.fedml_response import ResponseCode
+
+if response.code == ResponseCode.SUCCESS:
+    metadata = response.data
+    if metadata:
+        metadata_table = PrettyTable(["Data Name", "Description", "Created At", "Updated At"])
+    metadata_table.add_row([metadata.dataName, metadata.description, metadata.createdAt, metadata.updatedAt])
+
+print(metadata_table)
+```
+---
+### `fedml.api.get_storage_user_defined_metadata()`
+
+Get user-defined metadata of a data object stored on FEDML® Nexus AI Platform
+
+```py
+def get_storage_user_defined_metadata(data_name, api_key=None) -> FedMLResponse
+```
+
+**Arguments**
+
+- `data_name (str)`: The name of the data that was uploaded to FedML cloud storage.
+- `api_key (str=None)`: Your API key from FedML AI Nexus platform (if not configured already).
+
+**Returns**
+
+`FedMLResponse` object with the following attributes:
+- `code (Enum Class)`: API result code. The FedML response codes can be seen at the end of this page.
+- `message (str)`: API status message.
+- `data(obj)`: If the get call is successful, the dictionary that was uploaded by the user is present in this object.
+
+
+**Example**
+
+```py
+import fedml
+
+API_KEY = "api_key"
+DATA_NAME = "name_of_data_directory" #The name that was provided to platform during upload.
+
+response = fedml.api.get_storage_user_defined_metadata(
+    data_name=DATA_NAME,
+    api_key=API_KEY
+)
+
+```
+
+**Parsing the output**
+
+The following code shows how the dictionary can be retrieved from the response object.
+
+```py
+from fedml.api.fedml_response import ResponseCode
+
+if response.code == ResponseCode.SUCCESS:
+    metadata = response.data
+        if metadata:
+            print("User defined metadata ",response.data)
+```
+---
+
+### `fedml.api.list_storage_objects()`
+
+List data stored on FEDML® Nexus AI Platform
+
+```py
+def list_storage_objects(api_key=None) -> FedMLResponse
+```
+
+**Arguments**
+
+- `api_key (str=None)`: Your API key from FedML AI Nexus platform (if not configured already).
+
+**Returns**
+
+`FedMLResponse` object with the following attributes:
+- `code (Enum Class)`: API result code. The FedML response codes can be seen at the end of this page.
+- `message (str)`: API status message.
+- `data(obj)`: If the list command is successful, a list of data objects stored on the Nexus backend with its metadata is available.
+
+
+**Example**
+
+```py
+import fedml
+API_KEY = "api_key"
+
+response = fedml.api.list_storage_objects(api_key=API_KEY)
+
+```
+
+**Parsing the output**
+
+The following code shows how a pretty table can be built from the response object.
+
+```py
+from prettytable import PrettyTable
+from fedml.api.fedml_response import ResponseCode
+
+if response.code == ResponseCode.SUCCESS:
+    metadata = response.data
+    if metadata:
+        object_list_table = PrettyTable(["Data Name", "Description", "Created At", "Updated At"])
+        for stored_object in response.data:
+            object_list_table.add_row(
+                [stored_object.dataName, stored_object.description, stored_object.createdAt, stored_object.updatedAt])
+        print(object_list_table)
+```
+
+### ``` FedML ResponseCode Enum class ```
+
+```py
+class ResponseCode(Enum):
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+    ERROR = "ERROR"
+```

--- a/docs/open-source/cli/_category_.json
+++ b/docs/open-source/cli/_category_.json
@@ -3,6 +3,6 @@
   "position": 4,
   "link": {
     "type": "generated-index",
-    "description": "5 minutes to learn the most important Docusaurus concepts."
+    "description": "This is documentation for the various command line interfaces (CLIs) available with the FedML library"
   }
 }

--- a/docs/open-source/cli/fedml-storage.md
+++ b/docs/open-source/cli/fedml-storage.md
@@ -1,0 +1,192 @@
+---
+sidebar_position: 11
+---
+# Data Storage - fedml storage
+
+## FedML Storage CLI Overview
+
+
+Store and manage data on the FEDML® Nexus AI Platform.
+
+```bash
+❯ fedml storage
+Usage: fedml storage [OPTIONS] COMMAND [ARGS]...
+
+  Manage storage on FedML® Nexus AI Platform
+
+Options:
+  -h, --help          Show this message and exit.
+  -k, --api_key TEXT  user api key.
+  -v, --version TEXT  specify version of FedML® Nexus AI Platform. It should
+                      be dev, test or release
+
+Commands:
+  delete             Delete data stored on FedML® Nexus AI Platform
+  download           Download data stored on FedML® Nexus AI Platform
+  get-metadata       Get metadata of data object stored on FedML® Nexus 
+  get-user-metadata  Get user-defined metadata of data object stored on FedML® Nexus
+  list               List data stored on FedML® Nexus AI Platform
+  upload             Upload data on FedML® Nexus AI Platform
+```
+
+## Commands
+
+### `fedml storage upload [OPTIONS] DATA_PATH`
+
+Upload data on FedML® Nexus AI Platform
+
+#### Options {#options-1}
+
+| Name                        | Default | Description                                                  |
+|---------------------------  |---------|--------------------------------------------------------------|
+| `--help` or `-h`            |         | Show this message and exit.                                  |
+| `--name` or `-n`            |Current Data name  | Name your data to store.  |
+| `--description` or `-d`     |Empty description  |  Add description to your data to store.       |                      
+|  `--user_metadata` or `-um`   |  `None`|  User-defined metadata in the form of dictionary like {'name':'value'} within double quotes |
+| `--service` or `-s`         | `R2`  | Storage service for object storage. Only R2 available as of now.       |
+| `--api_key` or `-k` |   | User API key|
+| `--version` or `-v`       | `release` | The backend environment of FEDML Nexus AI Cloud.             |
+
+#### Example
+```bash
+fedml storage upload -d "This is visual common sense reasoning dataset annotations" path/to/dataset/vcr_annotations
+```
+#### CLI Response
+```bash     
+Uploading Package to Remote Storage: 100%|█████████████████████████████████████████████████████████████████████████████| 97.0M/97.0M [00:03<00:00, 24.6MB/s]
+Data uploaded successfully. | url: <Remote Storage URL> 
+```
+---
+### `fedml storage download [OPTIONS] DATA_NAME`
+
+Download data stored on FedML® Nexus AI Platform
+
+#### Options {#options-1}
+
+| Name                        | Default | Description                                                  |
+|---------------------------  |---------|--------------------------------------------------------------|
+| `--help` or `-h`            |         | Show this message and exit.                                  |
+| `--dest_path` or `-d`     | Current working directory  |  Destination path to download data.  |                      
+| `--service` or `-s`         | `R2`  | Storage service for object storage. Only R2 available as of now.       |
+| `--api_key` or `-k` |   | User API key|
+| `--version` or `-v`       | `release` | The backend environment of FEDML Nexus AI Cloud.             |
+
+#### Example
+
+```bash
+fedml storage download -d path/to/destination vcr_annotations
+```
+
+#### CLI Response
+```bash
+Downloading Package from Remote Storage: 100%|█████████████████████████████████████████████████████████████████████████| 97.0M/97.0M [00:04<00:00, 21.6MB/s]
+Data downloaded successfully at: path/to/destination
+```
+---
+### `fedml storage get-metadata [OPTIONS] DATA_NAME`
+
+Get metadata of data object stored on FedML® Nexus AI Platform
+
+#### Options
+
+| Name                        | Default | Description                                                  |
+|---------------------------  |---------|--------------------------------------------------------------|
+| `--help` or `-h`            |         | Show this message and exit.                                  |
+| `--api_key` or `-k` |   | User API key|
+| `--version` or `-v`       | `release` | The backend environment of FEDML Nexus AI Cloud.             |
+
+#### Example
+
+```bash
+fedml storage get-metadata vcr_annotations
+```
+
+#### CLI Response
+
+```bash
+Successfully fetched metadata for object vcr_annotations:
++-----------------+-----------------------------------------------------------+---------------------+---------------------+
+|    Data Name    |                        Description                        |      Created At     |      Updated At     |
++-----------------+-----------------------------------------------------------+---------------------+---------------------+
+| vcr_annotations | This is visual common sense reasoning dataset annotations | 2024-04-12T00:05:46 | 2024-04-12T00:05:46 |
++-----------------+-----------------------------------------------------------+---------------------+---------------------+
+```
+---
+### `fedml storage get-user-metadata [OPTIONS] DATA_NAME`
+
+Get user-defined metadata of data object stored on FedML® Nexus AI Platform
+
+#### Options
+
+| Name                        | Default | Description                                                  |
+|---------------------------  |---------|--------------------------------------------------------------|
+| `--help` or `-h`            |         | Show this message and exit.                                  |
+| `--api_key` or `-k` |   | User API key|
+| `--version` or `-v`       | `release` | The backend environment of FEDML Nexus AI Cloud.             |
+
+#### Example
+
+```bash
+fedml storage get-user-metadata vcr_annotations
+```
+
+#### CLI Response
+
+```bash
+Successfully fetched user-metadata for vcr_annotations:
+{'key1': 'value'}
+```
+---
+### `fedml storage list [OPTIONS]`
+
+List data stored on FedML® Nexus AI Platform
+
+#### Options
+
+| Name                        | Default | Description                                                  |
+|---------------------------  |---------|--------------------------------------------------------------|
+| `--help` or `-h`            |         | Show this message and exit.                                  |
+| `--api_key` or `-k` |   | User API key|
+| `--version` or `-v`       | `release` | The backend environment of FEDML Nexus AI Cloud.             |
+
+#### Example
+
+```bash
+fedml storage list
+```
+
+#### CLI Response
+
+```bash
+Successfully fetched list of stored objects:
++-----------------+-----------------------------------------------------------+---------------------+---------------------+
+|    Data Name    |                        Description                        |      Created At     |      Updated At     |
++-----------------+-----------------------------------------------------------+---------------------+---------------------+
+|  sample_dataset |                  This is a sample dataset                 | 2024-04-12T00:50:23 | 2024-04-12T00:50:23 |
+| vcr_annotations | This is visual common sense reasoning dataset annotations | 2024-04-12T00:05:46 | 2024-04-12T00:05:46 |
++-----------------+-----------------------------------------------------------+---------------------+---------------------+
+```
+---
+### `fedml storage delete [OPTIONS] DATA_NAME`
+
+Delete data stored on FedML® Nexus AI Platform
+
+#### Options {#options-1}
+
+| Name                        | Default | Description                                                  |
+|---------------------------  |---------|--------------------------------------------------------------|
+| `--help` or `-h`            |         | Show this message and exit.                                  |            
+| `--service` or `-s`         | `R2`  | Storage service for object storage. Only R2 available as of now.       |
+| `--api_key` or `-k` |   | User API key|
+| `--version` or `-v`       | `release` | The backend environment of FEDML Nexus AI Cloud.             |
+
+#### Example
+
+```bash
+fedml storage delete sample_dataset
+```
+
+#### CLI Response
+```bash
+Data 'sample_dataset' deleted successfully.
+```

--- a/docs/open-source/cli/index.md
+++ b/docs/open-source/cli/index.md
@@ -14,20 +14,22 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  login     Login the FedML® Nexus AI Platform.
-  logout    Logout from the FedML® Nexus AI Platform.
-  launch    Launch job at the FedML® Nexus AI platform.
-  cluster   Manage clusters on FedML® Nexus AI Platform.
+  login     Login the FedML® Nexus AI Platform
+  logout    Logout from the FedML® Nexus AI Platform
+  launch    Launch job at the FedML® Nexus AI Platform
+  cluster   Manage clusters on FedML® Nexus AI Platform
   run       Manage runs on the FedML® Nexus AI Platform.
-  device    Bind/unbind devices to the FedML® Nexus AI Platform.
-  model     Deploy and infer models.
-  build     Build packages for the FedML® Nexus AI Platform.
-  logs      Display logs for ongoing runs.
-  train     Manage training resources on FedML® Nexus AI Platform.
-  federate  Manage federated learning resources on FedML® Nexus AI Platform.
-  env       Get environment info such as versions, hardware, and networking.
-  network   Check the Nexus AI backend network connectivity.
-  version   Display FEDML library version.
+  device    Bind/unbind devices to the FedML® Nexus AI Platform
+  model     FedML Model CLI will help you manage the model cards, whether...
+  build     Build packages for the FedML® Nexus AI Platform
+  logs      Display logs for ongoing runs
+  train     Manage training resources on FedML® Nexus AI Platform
+  federate  Manage federated learning resources on FedML® Nexus AI Platform
+  storage   Manage storage on FedML® Nexus AI Platform
+  env       Get environment info such as versions, hardware, and networking
+  network   Check the Nexus AI backend network connectivity
+  version   Display FEDML library version
+
 ```
 
 :::tip

--- a/docs/storage/api.md
+++ b/docs/storage/api.md
@@ -1,7 +1,43 @@
 ---
 sidebar_position: 3
 ---
-
 # Python APIs
 
-### Hang tight, it's currently baking...
+## FedML Storage API Overview
+
+Storage APIs help in managing all the data needs that is typically associated with AI workloads.
+
+
+#### Example Usage
+
+```python
+import fedml
+from fedml.api.fedml_response import ResponseCode
+
+API_KEY = "api_key"
+
+DATA_PATH = "path/to/data"
+DATA_NAME = "new_name_for_data_directory or file"
+STORAGE_SERVICE = "R2"
+DATA_DESCRIPTION = "description of data uploaded"
+metadata = {'key': 'value'}
+
+response = fedml.api.upload(
+    data_path=DATA_PATH,
+    api_key=API_KEY,
+    service=STORAGE_SERVICE,
+    name=DATA_NAME,
+    description=DATA_DESCRIPTION,
+    metadata=metadata,
+    show_progress=True
+)
+
+if response.code == ResponseCode.SUCCESS:
+  print("Data has been uploaded!")
+else:
+  print("Issue in uploading the data.")
+
+```
+
+More about the storage APIs can be found [here](../open-source/api/api-storage#storage-apis)
+

--- a/docs/storage/cli.md
+++ b/docs/storage/cli.md
@@ -4,4 +4,30 @@ sidebar_position: 2
 
 # Command Line Interfaces (CLIs)
 
-### Hang tight, it's currently baking...
+## FEDML Storage CLI Overview
+
+Store and manage data on the FEDML® Nexus AI Platform.  This documentation covers details and examples of how to use these storage commands from a command line interface.
+
+
+```bash
+❯ fedml storage -h
+fedml storage [OPTIONS] COMMAND [ARGS]...
+  Manage storage on FedML® Nexus AI Platform
+
+Options:
+  -h, --help          Show this message and exit.
+  -k, --api_key TEXT  user api key.
+  -v, --version TEXT  specify version of FedML® Nexus AI Platform. It should
+                      be dev, test or release
+
+Commands:
+  delete             Delete data stored on FedML® Nexus AI Platform
+  download           Download data stored on FedML® Nexus AI Platform
+  get-metadata       Get metadata of data object stored on FedML® Nexus...
+  get-user-metadata  Get user-defined metadata of data object stored on...
+  list               List data stored on FedML® Nexus AI Platform
+  upload             Upload data on FedML® Nexus AI Platform
+
+```
+
+More about the `storage` CLI can be found [here](../open-source/cli/fedml-storage)

--- a/docs/storage/index.md
+++ b/docs/storage/index.md
@@ -4,4 +4,13 @@ sidebar_position: 1
 
 # What is FEDML®Storage?
 
-### Hang tight, it's currently baking...
+FEDML Storage is a suite of features that helps users address their data needs in ML Workflows. With simple Command Line Interface and API calls, users can do the following operations :
+
+- `Upload`: Upload data on FEDML® Nexus AI Platform
+- `Download` : Download data stored on FEDML® Nexus AI Platform
+- `Delete` : Delete data stored on FEDML® Nexus AI Platform
+- `List`: List data stored on FEDML® Nexus AI Platform
+- `Get Storage Metadata`: Get metadata of a data object stored on FEDML® Nexus AI Platform
+- `Get User Defined Metadata` : Get user-defined metadata of a data object stored on FEDML® Nexus AI Platform
+
+Such data functionality dovetails to various ML related workflows that we have observed with users.


### PR DESCRIPTION
Added Storage documentation.

**Scope of changes :** 

-docs/open-source/api/
-docs/open-source/cli
-docs/storage
-README.md

Also noticed - the default Docusaurus comment on the On-Premise Deployment page. Have added placeholder text. 
Made changes to the readme.md file

**Scope of changes :** 
-docs/launch/on-prem