### PR TITLE
feat: Add ability to inject data attributes from query-string - possibility to create an iframe/embed variant of a page.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,3 +1,6 @@
+const {
+  attributeQueryingPlugin,
+} = require('./plugins/attribute-querying-plugin.cjs');
 const { webpackPlugin } = require('./plugins/webpack-plugin.cjs');
 const tailwindPlugin = require('./plugins/tailwind-plugin.cjs');
 // const compressPlugin = require('./plugins/compress-images-plugin.cjs');
@@ -31,10 +34,11 @@ const resources = [
 ];
 
 const resourceMapper = Object.fromEntries(
-  resources.map((resource) => [resource.label, resource])
+  resources.map((resource) => [resource.label, resource]),
 );
 
 const plugins = [
+  attributeQueryingPlugin,
   tailwindPlugin,
   // ...docs_plugins,
   webpackPlugin,

--- a/plugins/attribute-querying-plugin.cjs
+++ b/plugins/attribute-querying-plugin.cjs
@@ -1,0 +1,40 @@
+// Support for ?docusaurus-data-mode=embed&docusaurus-attribute-myAttr=42
+const DataQueryStringPrefixKey = 'docusaurus-data-';
+
+/* language=js */
+const DataAttributeQueryStringInlineJavaScript = `
+(function() {
+  try {
+    const entries = new URLSearchParams(window.location.search).entries();
+    for (var [searchKey, value] of entries) {
+      if (searchKey.startsWith('${DataQueryStringPrefixKey}')) {
+        var key = searchKey.replace('${DataQueryStringPrefixKey}',"data-")
+        document.documentElement.setAttribute(key, value);
+      }
+    }
+  } catch(e) {}
+})();
+`;
+
+/**
+ * @type {import('@docusaurus/types').PluginModule}
+ */
+const attributeQueryingPlugin = () => {
+  return {
+    name: 'attribute-querying-plugin',
+    injectHtmlTags: () => {
+      return {
+        headTags: [
+          {
+            tagName: 'script',
+            innerHTML: `${DataAttributeQueryStringInlineJavaScript}`,
+          },
+        ],
+      };
+    },
+  };
+};
+
+module.exports = {
+  attributeQueryingPlugin,
+};

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,7 +4,7 @@
  * work well for content-centric websites.
  */
 
- @font-face {
+@font-face {
   font-family: 'Inter';
   font-weight: 100 900;
   font-display: block;
@@ -137,12 +137,12 @@
 @keyframes enter {
   0% {
     opacity: 0;
-    transform: translateY(10px)
+    transform: translateY(10px);
   }
 
   to {
     opacity: 1;
-    transform: none
+    transform: none;
   }
 }
 
@@ -152,14 +152,14 @@
   --start: 0ms;
 }
 
-@media (prefers-reduced-motion:no-preference) {
+@media (prefers-reduced-motion: no-preference) {
   [data-animate] {
-    animation: enter .6s both;
+    animation: enter 0.6s both;
     animation-delay: calc(var(--stagger) * var(--delay) + var(--start));
   }
 }
 
-[data-animation-controller=false] [data-animate] {
+[data-animation-controller='false'] [data-animate] {
   animation: none;
 }
 
@@ -761,4 +761,12 @@ html[data-theme='dark'] .dropdown > .navbar__link:after {
 
 .dropdown:hover > .navbar__link:after {
   background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.293 8.293a1 1 0 0 1 1.414 0L12 14.586l6.293-6.293a1 1 0 1 1 1.414 1.414l-7 7a1 1 0 0 1-1.414 0l-7-7a1 1 0 0 1 0-1.414Z' fill='%231a90ff'/%3E%3C/svg%3E") !important;
+}
+
+html[data-mode='iframe'] #__docusaurus > nav.navbar {
+  display: none;
+}
+
+html[data-mode='iframe'] #__docusaurus > .main-wrapper > div > aside {
+  display: none;
 }


### PR DESCRIPTION
## Motivation
Our documents are sometimes embedded in our platform in the form of iframes, and because the documents do not provide a layout option without navbar and sidebar, our platform side uses unconventional offset calculations to pan the document to the top left to hide the navigation and sidebar. 

This implementation is _unreliable_, it has a bad responsive layout 
<img width="1101" alt="image" src="https://github.com/FedML-AI/doc.fedml.ai/assets/19882767/90255191-44bf-4b0e-932f-97948d3fec10">
 on the laptop device, and it has some [layout shift](https://web.dev/articles/cls) issues, so I am going to design an easy and flexible way to provide an iframe mode from the document side.

We should be able to use `/docs/someDoc?docusaurus-data-mode=iframe` and then provide alternate styling for iframe/embedded rendering mode.

``` css
html[data-mode='iframe'] #__docusaurus > nav.navbar {
  display: none;
}

html[data-mode='iframe'] #__docusaurus > .main-wrapper > div > aside {
  display: none;
}
```

The system implemented allows you to inject arbitrary data-attribute values in the HTML, inlined (no FOUC / layout shifts expected), as long as they follow the `?docusaurus-data-<key>=<value>` pattern (value can be omitted)

## Test Plan
- Regular visit
https://doc-fedml-ai.vercel.app/train/train-on-cloud/train-on-fedml-cloud

<img width="1797" alt="image" src="https://github.com/FedML-AI/doc.fedml.ai/assets/19882767/414a5531-49e9-4471-8550-fcf2a61755e3">


- Visit after append query `?docusaurus-data-mode=iframe`
https://doc-fedml-ai.vercel.app/train/train-on-cloud/train-on-fedml-cloud?docusaurus-data-mode=iframe

<img width="1796" alt="image" src="https://github.com/FedML-AI/doc.fedml.ai/assets/19882767/e1e188a9-0408-4da2-b2ab-3ffe21a1f014">

