### PR TITLE
feat: install ssh proxy on gpu bind

### DIFF
--- a/static/shell/bind_gpu.sh
+++ b/static/shell/bind_gpu.sh
@@ -103,6 +103,14 @@ set_default_conda_env() {
     echo "conda" activate fedml >> "$HOME/.$1rc"
 }
 
+# Function to install and set up a SSH reverse proxy
+install_sshproxy() {
+    # get script from repo and run
+    curl https://raw.githubusercontent.com/TensorOpera-Inc/sshproxy/master/setup/install.sh -o /tmp/install_sshproxy.sh
+    chmod +x /tmp/install_sshproxy.sh
+    sudo /tmp/install_sshproxy.sh
+    rm /tmp/install_sshproxy.sh
+}
 
 # Stop unattended upgrades which result in /var/lib/dpkg/lock acquire race condition
 sudo systemctl stop unattended-upgrades
@@ -117,6 +125,7 @@ install_docker
 enable_docker_api_access
 install_redis
 install_nvidia_container_toolkit
+install_sshproxy
 set_default_conda_env "$default_shell"
 source ~/."${default_shell}rc"
 


### PR DESCRIPTION
add function call to `bind_gpu` script to install the SSH reverse proxy from our own builds hosted at https://github.com/TensorOpera-Inc/sshproxy

this addition: 
- downloads install script from `sshproxy` repo
- runs script as root

this allows us to multiplex multiple SSH servers hosted on separate containers through a single port on the bare metal