### PR TITLE
chore: add home description

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -107,6 +107,16 @@ const config = {
           hideable: true,
         },
       },
+      metadata: [
+        {
+          name: 'description',
+          content: 'Comprehensive documentation guide for TensorOpera. Covers Model Deployment, Serving, Training, Fine-tuning, Federate for efficient AI workflows.',
+        },
+        {
+          name: 'og:description',
+          content: 'Comprehensive documentation guide for TensorOpera. Covers Model Deployment, Serving, Training, Fine-tuning, Federate for efficient AI workflows.'
+        }
+      ],
       navbar: {
         title: 'TensorOpera AI Docs',
         logo: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,11 +8,9 @@ import HeroSection from '@site/src/components/homepage/HeroSection';
 import ProductLayerSection from '../components/homepage/ProductLayerSection';
 
 export default function Home() {
-  const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />"
+      description="Comprehensive documentation guide for TensorOpera. Covers Model Deployment, Serving, Training, Fine-tuning, Federate for efficient AI workflows."
     >
       <Head>
         <link rel="prefetch" href="/assets/css/elements.min.css" />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,9 +9,7 @@ import ProductLayerSection from '../components/homepage/ProductLayerSection';
 
 export default function Home() {
   return (
-    <Layout
-      description="Comprehensive documentation guide for TensorOpera. Covers Model Deployment, Serving, Training, Fine-tuning, Federate for efficient AI workflows."
-    >
+    <Layout>
       <Head>
         <link rel="prefetch" href="/assets/css/elements.min.css" />
       </Head>


### PR DESCRIPTION
docusaurus already comes built in with all the SEO features we need, but we are not utilizing them properly so far
this simply adds a proper title/description to home page

another PR needs to be raised to fix all the article documents and supply them with content like `description` (docusaurus currently takes the first paragraph as description)